### PR TITLE
fix: align list metadata with Read More

### DIFF
--- a/assets/scss/partials/article.scss
+++ b/assets/scss/partials/article.scss
@@ -93,7 +93,16 @@
         color: var(--card-text-color-tertiary);
     }
 
-    & > .inline-meta {
+    & > .article-meta-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-md);
+    }
+
+    & > .inline-meta,
+    & > .article-meta-row > .inline-meta {
         display: inline-flex;
         flex-wrap: wrap;
         align-items: center;

--- a/layouts/_partials/article/components/details.html
+++ b/layouts/_partials/article/components/details.html
@@ -1,5 +1,6 @@
 {{- $IsList := .IsList -}}
 {{- $Page := .Page -}}
+{{- $ArticleListFooter := partial "custom/article-list-footer.html" . -}}
 <div class="article-details">
     {{ if $Page.Params.categories }}
     <header class="article-category">
@@ -33,10 +34,13 @@
     {{ $showTime := or $showDate $showReadingTime }}
     {{ $showTranslations := $Page.IsTranslated }}
     {{ $showTags := and $Page.Site.Params.Article.List.ShowTags ($Page.GetTerms "tags") $IsList }}
+    {{ $showListFooter := and $IsList $ArticleListFooter }}
     
-    {{ if or $showTime $showTranslations $showTags }}
+    {{ if or $showTime $showTranslations $showTags $showListFooter }}
     <footer class="article-meta">
-        {{ if $showTime }}
+        {{ if or $showTime $showListFooter }}
+        <div class="article-meta-row">
+            {{ if $showTime }}
             <div class="inline-meta">
                 {{ if $showDate }}
                     {{ partial "helper/icon" "date" }}
@@ -52,6 +56,10 @@
                     </time>
                 {{ end }}
             </div>
+            {{ end }}
+
+            {{ $ArticleListFooter }}
+        </div>
         {{ end }}
 
         {{ if $showTranslations }}
@@ -73,6 +81,4 @@
         {{ end }}
     </footer>
     {{ end }}
-
-    {{ partial "custom/article-list-footer.html" . }}
 </div>


### PR DESCRIPTION
## Summary

- render list extension content in the same metadata row as date and reading time
- keep translations and tags as separate Stack v4 metadata groups
- omit the row when the default extension hook has no content
- allow the row to wrap naturally on narrow screens

## Validation

- Hugo `0.160.1+extended`: theme demo build with `--panicOnWarning`
- Hugo `0.160.1+extended`: Blog-Hugo integration build with `--panicOnWarning`
- Hugo `0.164.0+extended`: Blog-Hugo integration build with `--panicOnWarning`
- generated homepage places `.article-readmore` inside `.article-meta-row`
